### PR TITLE
Reformat Readme.md to show clone commands as code

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,14 @@
 - Modular component architecture
 - Local storage persistence
 - Hacktoberfest-friendly issues
-
+```
 git clone https://github.com/vatsark9/plumdejour.git
 cd plumdejour
 npm install
 npm run dev
-App will be live at http://localhost:5173
+```
+> App will be live at http://localhost:5173
+
 .
 
 ## 🤝 Contributing


### PR DESCRIPTION
The steps including clone commands and running on local were shown inline.

I've reformatted it as codeblock instead.

If you suggest, we can remove this even totally since it's duplicate. We are currently showing the steps to run on the localhost twice.

Let me know what do you think?